### PR TITLE
ci: issue-2 PRコメントトリガーのCI workflowを追加

### DIFF
--- a/.github/workflows/pr-comment-ci.yml
+++ b/.github/workflows/pr-comment-ci.yml
@@ -1,0 +1,159 @@
+name: PR Comment CI
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-command:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/ci')
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.check.outputs.should-run }}
+    steps:
+      - name: Check if comment is /ci command
+        id: check
+        run: |
+          if [[ "${{ github.event.comment.body }}" == "/ci" ]]; then
+            echo "should-run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should-run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: React to comment
+        if: steps.check.outputs.should-run == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            })
+
+  ci:
+    needs: check-command
+    if: needs.check-command.outputs.should-run == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR information
+        uses: actions/github-script@v7
+        id: pr-info
+        with:
+          script: |
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('head-ref', pullRequest.head.ref);
+            core.setOutput('head-sha', pullRequest.head.sha);
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr-info.outputs.head-sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type check
+        id: typecheck
+        run: |
+          echo "## Type Check" >> $GITHUB_STEP_SUMMARY
+          if npm run typecheck; then
+            echo "✅ Type check passed" >> $GITHUB_STEP_SUMMARY
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Type check failed" >> $GITHUB_STEP_SUMMARY
+            echo "status=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run format check
+        id: format
+        run: |
+          echo "## Format Check" >> $GITHUB_STEP_SUMMARY
+          if npm run format:check; then
+            echo "✅ Format check passed" >> $GITHUB_STEP_SUMMARY
+            echo "status=success" >> $GITHUB_OUTPUT
+          else
+            echo "❌ Format check failed" >> $GITHUB_STEP_SUMMARY
+            echo "status=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run tests with coverage
+        id: test
+        run: |
+          echo "## Test Coverage" >> $GITHUB_STEP_SUMMARY
+          npm run test:coverage > coverage-output.txt 2>&1 || TEST_EXIT_CODE=$?
+          
+          # Display test results
+          if grep -E "(Test Files|Tests)" coverage-output.txt; then
+            grep -E "(Test Files|Tests)" coverage-output.txt >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Extract and display coverage
+          if grep -A 5 "Coverage summary" coverage-output.txt; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "### Coverage Summary" >> $GITHUB_STEP_SUMMARY
+            grep -A 5 "Coverage summary" coverage-output.txt >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          # Extract coverage percentage for statements
+          COVERAGE=$(grep "All files" coverage-output.txt | awk -F'|' '{print $2}' | tr -d ' %' || echo "0")
+          echo "coverage=${COVERAGE}" >> $GITHUB_OUTPUT
+          
+          # Check if tests passed
+          if [ "${TEST_EXIT_CODE:-0}" -ne 0 ]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=success" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Post results to PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const typeCheckStatus = '${{ steps.typecheck.outputs.status }}' === 'success' ? '✅' : '❌';
+            const formatStatus = '${{ steps.format.outputs.status }}' === 'success' ? '✅' : '❌';
+            const testStatus = '${{ steps.test.outputs.status }}' === 'success' ? '✅' : '❌';
+            const coverage = '${{ steps.test.outputs.coverage }}' || 'N/A';
+            
+            const body = `## CI Results
+            
+            | Check | Status |
+            |-------|--------|
+            | Type Check | ${typeCheckStatus} |
+            | Format | ${formatStatus} |
+            | Tests | ${testStatus} |
+            | Coverage | ${coverage}% |
+            
+            <details>
+            <summary>詳細ログ</summary>
+            
+            [ワークフロー実行ログを確認](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+            
+            </details>
+            
+            ---
+            _Triggered by @${context.actor} with \`/ci\` command_`;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body
+            });

--- a/docs/開発ルール.md
+++ b/docs/開発ルール.md
@@ -77,6 +77,18 @@ npm run test:coverage # カバレッジ89%以上
 3. **Test**: テスト失敗でfail
 4. **Coverage**: カバレッジ不足でfail
 
+### GitHub Actions CI
+- **トリガー**: PRにコメント `/ci` を投稿
+- **実行内容**:
+  - TypeScript型チェック (`npm run typecheck`)
+  - フォーマットチェック (`npm run format:check`)
+  - テスト実行とカバレッジ計測 (`npm run test:coverage`)
+- **結果報告**: CIの実行結果とカバレッジをPRコメントに自動投稿
+- **使用方法**:
+  1. PRを作成
+  2. PRに `/ci` とコメント
+  3. CIが自動実行され、結果がコメントで通知される
+
 ## コミット・PR規則
 
 ### コミットメッセージ

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "biome lint src/",
     "lint:fix": "biome lint --write src/",
     "format": "biome format src/",
+    "format:check": "biome format src/",
     "format:fix": "biome format --write src/",
     "check": "biome check src/",
     "check:fix": "biome check --write src/",


### PR DESCRIPTION
## 概要
PR上で `/ci` コメントをトリガーとして実行されるGitHub Actions CIワークフローを追加しました。

## 変更内容
- `.github/workflows/pr-comment-ci.yml` - 新しいCIワークフローファイルを作成
- `package.json` - `format:check` コマンドを追加（CIでのフォーマットチェック用）
- `docs/開発ルール.md` - GitHub Actions CIの使用方法を文書化

## 実装詳細
### トリガー
- PRに `/ci` とコメントすることでCIが起動
- 🚀 リアクションでCIの開始を通知

### 実行内容
1. **TypeScript型チェック** (`npm run typecheck`)
2. **フォーマットチェック** (`npm run format:check`)
3. **テスト実行とカバレッジ計測** (`npm run test:coverage`)

### 結果報告
- CI実行結果（各チェックのステータス）
- テストカバレッジ率
- 結果をPRコメントとして自動投稿

## テスト方法
1. このPRに `/ci` とコメントを投稿
2. CIが自動実行されることを確認
3. 結果がPRコメントに投稿されることを確認

close #2