### PR TITLE
feat: issue-3 デフォルト動作を単発実行に変更しwatchサブコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ cctrackerは、Claude AIのトークン使用量をリアルタイムで監視�
 
 ## 特徴
 
-- 🔄 **リアルタイム監視** - 3秒ごとに使用状況を更新
+- 📊 **クイック確認** - 現在の使用状況を即座に表示して終了（デフォルト動作）
+- 🔄 **リアルタイム監視** - watchモードで3秒ごとに使用状況を継続更新
 - 📊 **視覚的なプログレスバー** - トークン使用率を色分けして表示
 - 🔮 **スマート予測** - 現在の消費速度から枯渇時刻を予測
 - 🤖 **自動プラン検出** - 過去の使用履歴から利用中のプランを自動判定
@@ -44,20 +45,23 @@ npm run dev
 ### 基本的な使用方法
 
 ```bash
-# 自動プラン検出で起動（推奨）
+# 現在の使用状況を確認（単発実行、デフォルト）
 npx cctracker
 
-# 手動でプランを指定
-npx cctracker --plan max5
+# 継続的に監視（watchモード）
+npx cctracker watch
 
-# 自動検出を無効化してProプランで起動
+# watchモードで手動プランを指定
+npx cctracker watch --plan max5
+
+# watchモードでリフレッシュ間隔を変更（秒単位）
+npx cctracker watch --refresh 5
+
+# 自動検出を無効化してProプランで確認
 npx cctracker --plan pro --no-auto-detect
 
 # カスタムデータパスを指定
 npx cctracker --data-path /path/to/claude/data
-
-# リフレッシュ間隔を変更（秒単位）
-npx cctracker --refresh 5
 
 # 使用状況の詳細情報を確認
 npx cctracker info

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -69,13 +69,6 @@ program
       dataPath: options.dataPath,
     });
 
-    console.log('\n📊 Claude Code Usage Status');
-    console.log(`📋 Plan: ${plan}`);
-
-    if (options.dataPath) {
-      console.log(`📁 Data path: ${options.dataPath}`);
-    }
-
     try {
       await monitor.runOnce();
     } catch (error) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,6 @@ program
 program
   .option('-p, --plan <type>', 'Subscription plan (pro, max5, max20, custom_max, auto)', 'auto')
   .option('-d, --data-path <path>', 'Custom path to Claude data directory')
-  .option('-r, --refresh <seconds>', 'Refresh interval in seconds', '3')
   .option('--no-auto-detect', 'Disable automatic plan detection')
   .action(async (options) => {
     // Handle plan detection
@@ -64,32 +63,23 @@ program
       plan = options.plan as Plan;
     }
 
-    // Parse refresh interval
-    const refreshInterval = parseInt(options.refresh) * 1000;
-    if (Number.isNaN(refreshInterval) || refreshInterval < 1000) {
-      console.error('Refresh interval must be at least 1 second');
-      process.exit(1);
-    }
-
-    // Create and start monitor
+    // Create monitor
     const monitor = new Monitor({
       plan,
       dataPath: options.dataPath,
-      refreshInterval,
     });
 
-    console.log('\n🚀 Starting Claude Code Usage Monitor...');
+    console.log('\n📊 Claude Code Usage Status');
     console.log(`📋 Plan: ${plan}`);
-    console.log(`🔄 Refresh interval: ${options.refresh}s`);
 
     if (options.dataPath) {
       console.log(`📁 Data path: ${options.dataPath}`);
     }
 
     try {
-      await monitor.start();
+      await monitor.runOnce();
     } catch (error) {
-      console.error('Failed to start monitor:', error);
+      console.error('Failed to fetch usage data:', error);
       process.exit(1);
     }
   });
@@ -151,6 +141,81 @@ program
     console.log('  - Use --data-path option to override the default path');
     console.log('  - Use --plan auto (or just omit --plan) for automatic plan detection');
     console.log('  - Make sure Claude Code is running and has created session data');
+  });
+
+// Add watch command for continuous monitoring
+program
+  .command('watch')
+  .description('Continuously monitor Claude usage with live updates')
+  .option('-p, --plan <type>', 'Subscription plan (pro, max5, max20, custom_max, auto)', 'auto')
+  .option('-d, --data-path <path>', 'Custom path to Claude data directory')
+  .option('-r, --refresh <seconds>', 'Refresh interval in seconds', '3')
+  .option('--no-auto-detect', 'Disable automatic plan detection')
+  .action(async (options) => {
+    // Handle plan detection (same as default command)
+    let plan: Plan = 'pro';
+
+    if (options.plan === 'auto' || (options.autoDetect && options.plan === 'pro')) {
+      console.log('🔍 Auto-detecting plan from usage history...');
+
+      try {
+        const dataLoader = new DataLoader(options.dataPath);
+        const sessionIdentifier = new SessionIdentifier();
+        const planDetector = new PlanDetector();
+
+        const entries = await dataLoader.loadUsageData();
+        const blocks = sessionIdentifier.createSessionBlocks(entries);
+        const analysis = planDetector.analyzePlanUsage(blocks);
+
+        plan = analysis.detectedPlan;
+
+        console.log(`✅ Detected plan: ${plan} (confidence: ${analysis.confidence})`);
+        if (analysis.recommendation) {
+          console.log(`💡 ${analysis.recommendation}`);
+        }
+        console.log(`📊 Max tokens used: ${analysis.maxTokensUsed.toLocaleString()}`);
+      } catch (_error) {
+        console.warn('⚠️  Could not auto-detect plan, using default (pro)');
+        plan = 'pro';
+      }
+    } else {
+      const validPlans: Plan[] = ['pro', 'max5', 'max20', 'custom_max'];
+      if (!validPlans.includes(options.plan as Plan)) {
+        console.error(`Invalid plan: ${options.plan}`);
+        console.error(`Valid plans are: ${validPlans.join(', ')}`);
+        process.exit(1);
+      }
+      plan = options.plan as Plan;
+    }
+
+    // Parse refresh interval
+    const refreshInterval = parseInt(options.refresh) * 1000;
+    if (Number.isNaN(refreshInterval) || refreshInterval < 1000) {
+      console.error('Refresh interval must be at least 1 second');
+      process.exit(1);
+    }
+
+    // Create and start monitor
+    const monitor = new Monitor({
+      plan,
+      dataPath: options.dataPath,
+      refreshInterval,
+    });
+
+    console.log('\n🚀 Starting Claude Code Usage Monitor...');
+    console.log(`📋 Plan: ${plan}`);
+    console.log(`🔄 Refresh interval: ${options.refresh}s`);
+
+    if (options.dataPath) {
+      console.log(`📁 Data path: ${options.dataPath}`);
+    }
+
+    try {
+      await monitor.start();
+    } catch (error) {
+      console.error('Failed to start monitor:', error);
+      process.exit(1);
+    }
   });
 
 program.parse();

--- a/src/cli/monitor.test.ts
+++ b/src/cli/monitor.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Monitor } from './monitor.js';
+import type { Plan } from '../models/types.js';
+
+// Type definition for testing private methods
+type MonitorWithPrivateMethods = Monitor & {
+  update: () => Promise<void>;
+  intervalId?: NodeJS.Timeout;
+  isRunning: boolean;
+  formatter: {
+    hideCursor: () => void;
+  };
+};
+
+// モック
+vi.mock('../core/dataLoader.js');
+vi.mock('../core/sessionIdentifier.js');
+vi.mock('../core/tokenCalculator.js');
+vi.mock('../core/burnRateCalculator.js');
+vi.mock('./formatter.js');
+
+describe('Monitor', () => {
+  let monitor: Monitor;
+  let monitorWithPrivate: MonitorWithPrivateMethods;
+  let _consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let _processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    monitor = new Monitor({
+      plan: 'pro' as Plan,
+      refreshInterval: 1000,
+    });
+    monitorWithPrivate = monitor as MonitorWithPrivateMethods;
+    _consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    _processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('Process exit');
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('runOnce', () => {
+    it('should update once and exit without starting interval', async () => {
+      // This test will fail initially as runOnce method doesn't exist yet
+      expect(monitor.runOnce).toBeDefined();
+      
+      // Mock the private update method
+      const updateSpy = vi.spyOn(monitorWithPrivate, 'update').mockResolvedValue(undefined);
+      
+      await monitor.runOnce();
+      
+      // Should call update exactly once
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      
+      // Should not set up any intervals
+      expect(monitorWithPrivate.intervalId).toBeUndefined();
+      
+      // Should not hide cursor (as it's a one-time run)
+      expect(monitorWithPrivate.formatter.hideCursor).not.toHaveBeenCalled();
+    });
+
+    it('should handle errors gracefully during runOnce', async () => {
+      const errorMessage = 'Test error';
+      vi.spyOn(monitorWithPrivate, 'update').mockRejectedValue(new Error(errorMessage));
+      
+      await expect(monitor.runOnce()).rejects.toThrow(errorMessage);
+    });
+  });
+
+  describe('start', () => {
+    it('should set up continuous monitoring with interval', async () => {
+      const updateSpy = vi.spyOn(monitorWithPrivate, 'update').mockResolvedValue(undefined);
+      
+      // Start the monitor
+      monitor.start();
+      
+      // Initial update should be called
+      await new Promise(resolve => setTimeout(resolve, 50));
+      expect(updateSpy).toHaveBeenCalledTimes(1);
+      
+      // Should set up interval
+      expect(monitorWithPrivate.intervalId).toBeDefined();
+      
+      // Should hide cursor for continuous monitoring
+      expect(monitorWithPrivate.formatter.hideCursor).toHaveBeenCalled();
+      
+      // Clear interval without calling stop() to avoid process.exit
+      clearInterval(monitorWithPrivate.intervalId);
+      monitorWithPrivate.isRunning = false;
+    });
+  });
+});

--- a/src/cli/monitor.test.ts
+++ b/src/cli/monitor.test.ts
@@ -5,6 +5,7 @@ import type { Plan } from '../models/types.js';
 // Type definition for testing private methods
 type MonitorWithPrivateMethods = Monitor & {
   update: () => Promise<void>;
+  updateOnce: () => Promise<void>;
   intervalId?: NodeJS.Timeout;
   isRunning: boolean;
   formatter: {
@@ -46,13 +47,13 @@ describe('Monitor', () => {
       // This test will fail initially as runOnce method doesn't exist yet
       expect(monitor.runOnce).toBeDefined();
       
-      // Mock the private update method
-      const updateSpy = vi.spyOn(monitorWithPrivate, 'update').mockResolvedValue(undefined);
+      // Mock the private updateOnce method
+      const updateOnceSpy = vi.spyOn(monitorWithPrivate, 'updateOnce').mockResolvedValue(undefined);
       
       await monitor.runOnce();
       
-      // Should call update exactly once
-      expect(updateSpy).toHaveBeenCalledTimes(1);
+      // Should call updateOnce exactly once
+      expect(updateOnceSpy).toHaveBeenCalledTimes(1);
       
       // Should not set up any intervals
       expect(monitorWithPrivate.intervalId).toBeUndefined();
@@ -63,7 +64,7 @@ describe('Monitor', () => {
 
     it('should handle errors gracefully during runOnce', async () => {
       const errorMessage = 'Test error';
-      vi.spyOn(monitorWithPrivate, 'update').mockRejectedValue(new Error(errorMessage));
+      vi.spyOn(monitorWithPrivate, 'updateOnce').mockRejectedValue(new Error(errorMessage));
       
       await expect(monitor.runOnce()).rejects.toThrow(errorMessage);
     });

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -63,6 +63,11 @@ export class Monitor {
     process.exit(0);
   }
 
+  async runOnce(): Promise<void> {
+    // One-time execution without setting up intervals or cursor management
+    await this.update();
+  }
+
   private async update(): Promise<void> {
     try {
       // Load and process data

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -65,7 +65,7 @@ export class Monitor {
 
   async runOnce(): Promise<void> {
     // One-time execution without setting up intervals or cursor management
-    await this.update();
+    await this.updateOnce();
   }
 
   private async update(): Promise<void> {
@@ -175,5 +175,112 @@ export class Monitor {
     }
 
     console.log(`\n${this.formatter.formatSuccess('Press Ctrl+C to exit')}`);
+  }
+
+  private async updateOnce(): Promise<void> {
+    try {
+      // Load and process data
+      const entries = await this.dataLoader.loadUsageData();
+      const blocks = this.sessionIdentifier.createSessionBlocks(entries);
+
+      // Find active session
+      const activeBlock = blocks.find((b) => b.isActive && !b.isGap) || null;
+
+      // Calculate metrics
+      const currentTokens = activeBlock
+        ? this.tokenCalculator.calculateBlockWeightedTokens(activeBlock)
+        : 0;
+
+      const limit = this.tokenCalculator.determinePlanLimit(this.options.plan, blocks);
+      const percentage = this.tokenCalculator.calculateTokenPercentage(currentTokens, limit);
+      const burnRate = this.burnRateCalculator.calculateHourlyBurnRate(blocks);
+      const burnRateIndicator = this.burnRateCalculator.getBurnRateIndicator(
+        burnRate.tokensPerMinute
+      );
+
+      // Check for plan auto-switching
+      if (this.options.plan === 'pro' && currentTokens > 44000) {
+        this.options.plan = 'custom_max';
+        console.log(
+          this.formatter.formatWarning(
+            'Detected usage above Pro limit. Switching to custom_max mode.'
+          )
+        );
+      }
+
+      // Calculate projections
+      const projection = this.burnRateCalculator.projectUsage(
+        activeBlock,
+        currentTokens,
+        limit,
+        burnRate
+      );
+
+      const depletionTime = this.burnRateCalculator.calculateDepletionTime(
+        currentTokens,
+        limit,
+        burnRate
+      );
+
+      // Display for single run (no screen clear, no exit message)
+      this.displayOnce({
+        plan: this.options.plan,
+        currentTokens,
+        limit,
+        percentage,
+        burnRate,
+        burnRateIndicator,
+        activeBlock,
+        projection,
+        depletionTime,
+      });
+    } catch (error) {
+      console.error(
+        this.formatter.formatError(
+          `Error fetching usage data: ${error instanceof Error ? error.message : 'Unknown error'}`
+        )
+      );
+    }
+  }
+
+  private displayOnce(data: {
+    plan: Plan;
+    currentTokens: number;
+    limit: number;
+    percentage: number;
+    burnRate: BurnRate;
+    burnRateIndicator: string;
+    activeBlock: SessionBlock | null;
+    projection: UsageProjection | null;
+    depletionTime: Date | null;
+  }): void {
+    // No screen clear for single run
+    console.log('\n🎯 Claude Code Usage Status\n');
+    console.log(`Plan: ${this.formatter.formatPlan(data.plan)}`);
+    console.log('─'.repeat(60));
+
+    // Token usage
+    console.log(this.formatter.formatTokenStatus(data.currentTokens, data.limit, data.percentage));
+    console.log(this.formatter.formatProgressBar(data.percentage));
+
+    console.log('─'.repeat(60));
+
+    // Burn rate
+    console.log(this.formatter.formatBurnRate(data.burnRate, data.burnRateIndicator));
+
+    // Session info
+    console.log(this.formatter.formatSessionInfo(data.activeBlock));
+
+    // Warnings
+    if (data.depletionTime && data.activeBlock) {
+      if (isBefore(data.depletionTime, data.activeBlock.endTime)) {
+        console.log(this.formatter.formatWarning(`Tokens will deplete before session reset!`));
+      }
+    }
+
+    if (data.percentage >= 90) {
+      console.log(this.formatter.formatWarning('Token limit nearly reached!'));
+    }
+    // No "Press Ctrl+C to exit" message for single run
   }
 }


### PR DESCRIPTION
## 概要
CLIのデフォルト動作を継続的な監視から単発実行に変更し、従来の監視機能を`watch`サブコマンドに移動しました。

## 変更内容
### 機能追加
- `Monitor`クラスに`runOnce()`メソッドを追加（単発実行用）
- `watch`サブコマンドを新規追加

### 動作変更
- **デフォルト動作** (`npx cctracker`): 現在の使用状況を表示して終了
- **監視モード** (`npx cctracker watch`): 3秒ごとに更新される継続的な監視

### ドキュメント更新
- README.mdを更新し、新しい使用方法を反映

## 実装詳細
- TDDアプローチで実装（Red→Green→Blue→Commit）
- `runOnce`メソッドのテストを作成
- 型安全性を維持しながら実装

## テスト
- ✅ 105個のテストが全て通過
- ✅ Lintチェック通過
- ✅ 型チェック通過

## 使用例
```bash
# 現在の使用状況を確認（デフォルト）
npx cctracker

# 継続的に監視
npx cctracker watch

# watchモードでオプション指定
npx cctracker watch --refresh 5 --plan max5
```

close #3